### PR TITLE
remove useless jdbc version in pom and catch throwable exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
@@ -40,6 +39,11 @@
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>1.2.17</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.iotdb</groupId>
+			<artifactId>iotdb-jdbc</artifactId>
+			<version>0.8.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.influxdb</groupId>
@@ -60,11 +64,6 @@
 		    <groupId>com.alibaba</groupId>
 		    <artifactId>fastjson</artifactId>
 		    <version>1.2.31</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.iotdb</groupId>
-			<artifactId>iotdb-jdbc</artifactId>
-			<version>0.8.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,18 +32,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>cn.edu.tsinghua</groupId>
-			<artifactId>iotdb-jdbc</artifactId>
-			<version>0.7.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.iotdb</groupId>
-			<artifactId>iotdb-jdbc</artifactId>
-			<version>0.8.0-SNAPSHOT</version>
-		</dependency>
-
-		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>${common.cli.version}</version>
@@ -72,6 +60,16 @@
 		    <groupId>com.alibaba</groupId>
 		    <artifactId>fastjson</artifactId>
 		    <version>1.2.31</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.iotdb</groupId>
+			<artifactId>iotdb-jdbc</artifactId>
+			<version>0.8.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.10.1</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/tsdb/iotdb/IoTDB.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/tsdb/iotdb/IoTDB.java
@@ -159,10 +159,8 @@ public class IoTDB implements IDatabase {
   }
 
   /**
-   * SELECT s_39 FROM root.group_2.d_29
-   * WHERE time >= 2010-01-01 12:00:00
-   * AND time <= 2010-01-01 12:30:00
-   * AND root.group_2.d_29.s_39 > 0.0
+   * SELECT s_39 FROM root.group_2.d_29 WHERE time >= 2010-01-01 12:00:00 AND time <= 2010-01-01
+   * 12:30:00 AND root.group_2.d_29.s_39 > 0.0
    */
   @Override
   public Status valueRangeQuery(ValueRangeQuery valueRangeQuery) {
@@ -171,9 +169,8 @@ public class IoTDB implements IDatabase {
   }
 
   /**
-   * SELECT max_value(s_76) FROM root.group_3.d_31
-   * WHERE time >= 2010-01-01 12:00:00
-   * AND time <= 2010-01-01 12:30:00
+   * SELECT max_value(s_76) FROM root.group_3.d_31 WHERE time >= 2010-01-01 12:00:00 AND time <=
+   * 2010-01-01 12:30:00
    */
   @Override
   public Status aggRangeQuery(AggRangeQuery aggRangeQuery) {
@@ -185,8 +182,7 @@ public class IoTDB implements IDatabase {
   }
 
   /**
-   * SELECT max_value(s_39) FROM root.group_2.d_29
-   * WHERE root.group_2.d_29.s_39 > 0.0
+   * SELECT max_value(s_39) FROM root.group_2.d_29 WHERE root.group_2.d_29.s_39 > 0.0
    */
   @Override
   public Status aggValueQuery(AggValueQuery aggValueQuery) {
@@ -198,8 +194,8 @@ public class IoTDB implements IDatabase {
   }
 
   /**
-   * SELECT max_value(s_39) FROM root.group_2.d_29 WHERE time >= 2010-01-01 12:00:00 AND
-   * time <= 2010-01-01 12:30:00 AND root.group_2.d_29.s_39 > 0.0
+   * SELECT max_value(s_39) FROM root.group_2.d_29 WHERE time >= 2010-01-01 12:00:00 AND time <=
+   * 2010-01-01 12:30:00 AND root.group_2.d_29.s_39 > 0.0
    */
   @Override
   public Status aggRangeValueQuery(AggRangeValueQuery aggRangeValueQuery) {
@@ -214,9 +210,8 @@ public class IoTDB implements IDatabase {
 
   /**
    * select aggFun(sensor) from device group by(interval, startTimestamp, [startTimestamp,
-   * endTimestamp])
-   * example: SELECT max_value(s_81) FROM root.group_9.d_92
-   * GROUP BY(600000ms, 1262275200000,[2010-01-01 12:00:00,2010-01-01 13:00:00])
+   * endTimestamp]) example: SELECT max_value(s_81) FROM root.group_9.d_92 GROUP BY(600000ms,
+   * 1262275200000,[2010-01-01 12:00:00,2010-01-01 13:00:00])
    */
   @Override
   public Status groupByQuery(GroupByQuery groupByQuery) {
@@ -342,6 +337,8 @@ public class IoTDB implements IDatabase {
       return new Status(true, en - st, queryResultPointNum);
     } catch (Exception e) {
       return new Status(false, 0, queryResultPointNum, e, sql);
+    } catch (Throwable t) {
+      return new Status(false, 0, queryResultPointNum, new Exception(t), sql);
     }
   }
 

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/tsdb/iotdb/IoTDB.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/tsdb/iotdb/IoTDB.java
@@ -159,8 +159,10 @@ public class IoTDB implements IDatabase {
   }
 
   /**
-   * SELECT s_39 FROM root.group_2.d_29 WHERE time >= 2010-01-01 12:00:00 AND time <= 2010-01-01
-   * 12:30:00 AND root.group_2.d_29.s_39 > 0.0
+   * SELECT s_39 FROM root.group_2.d_29
+   * WHERE time >= 2010-01-01 12:00:00
+   * AND time <= 2010-01-01 12:30:00
+   * AND root.group_2.d_29.s_39 > 0.0
    */
   @Override
   public Status valueRangeQuery(ValueRangeQuery valueRangeQuery) {
@@ -169,8 +171,9 @@ public class IoTDB implements IDatabase {
   }
 
   /**
-   * SELECT max_value(s_76) FROM root.group_3.d_31 WHERE time >= 2010-01-01 12:00:00 AND time <=
-   * 2010-01-01 12:30:00
+   * SELECT max_value(s_76) FROM root.group_3.d_31
+   * WHERE time >= 2010-01-01 12:00:00
+   * AND time <= 2010-01-01 12:30:00
    */
   @Override
   public Status aggRangeQuery(AggRangeQuery aggRangeQuery) {
@@ -182,7 +185,8 @@ public class IoTDB implements IDatabase {
   }
 
   /**
-   * SELECT max_value(s_39) FROM root.group_2.d_29 WHERE root.group_2.d_29.s_39 > 0.0
+   * SELECT max_value(s_39) FROM root.group_2.d_29
+   * WHERE root.group_2.d_29.s_39 > 0.0
    */
   @Override
   public Status aggValueQuery(AggValueQuery aggValueQuery) {
@@ -194,8 +198,8 @@ public class IoTDB implements IDatabase {
   }
 
   /**
-   * SELECT max_value(s_39) FROM root.group_2.d_29 WHERE time >= 2010-01-01 12:00:00 AND time <=
-   * 2010-01-01 12:30:00 AND root.group_2.d_29.s_39 > 0.0
+   * SELECT max_value(s_39) FROM root.group_2.d_29 WHERE time >= 2010-01-01 12:00:00 AND
+   * time <= 2010-01-01 12:30:00 AND root.group_2.d_29.s_39 > 0.0
    */
   @Override
   public Status aggRangeValueQuery(AggRangeValueQuery aggRangeValueQuery) {
@@ -210,8 +214,9 @@ public class IoTDB implements IDatabase {
 
   /**
    * select aggFun(sensor) from device group by(interval, startTimestamp, [startTimestamp,
-   * endTimestamp]) example: SELECT max_value(s_81) FROM root.group_9.d_92 GROUP BY(600000ms,
-   * 1262275200000,[2010-01-01 12:00:00,2010-01-01 13:00:00])
+   * endTimestamp])
+   * example: SELECT max_value(s_81) FROM root.group_9.d_92
+   * GROUP BY(600000ms, 1262275200000,[2010-01-01 12:00:00,2010-01-01 13:00:00])
    */
   @Override
   public Status groupByQuery(GroupByQuery groupByQuery) {


### PR DESCRIPTION
1、去掉了pom文件中没有用到的cn.edu.tsinghua.iotdb下的jdbc引用，有2个jdbc容易造成误解
2、在IoTDB.java类的查询方法中增加了catch throwable，这样当由于jdbc版本使用错误等造成抛出Throwable时更容易定位问题