### PR TITLE
imp query workload for real data

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -23,9 +23,8 @@ DB_NAME=test
 ### benchmark运行模式选择参数 ###
 #目前支持多种运行模式，分别为：
 #testWithDefaultPath--常规测试模式，支持多种读和写操作的混合负载
-#testWithRealDataSet--写入真实数据集模式，需要配置 FILE_PATH 以及 DATA_SET
-#queryWithRealDataSet--查询真实数据集模式，需要配置REAL_QUERY_START_TIME, REAL_QUERY_STOP_TIME,
-# DATA_SET 以及 testWithDefaultPath模式下查询有关参数
+#writeWithRealDataSet--写入真实数据集模式，需要配置 FILE_PATH 以及 DATA_SET
+#queryWithRealDataSet--查询真实数据集模式，需要配置REAL_QUERY_START_TIME, REAL_QUERY_STOP_TIME, DATA_SET 以及 testWithDefaultPath模式下查询有关参数
 #insertTestWithDefaultPath--重构前的纯写入模式
 #queryTestWithDefaultPath--重构前的纯查询模式
 #insertTestWithUserDefinedPath--样例数据生成模式

--- a/conf/config.properties
+++ b/conf/config.properties
@@ -24,6 +24,8 @@ DB_NAME=test
 #目前支持5种运行模式，分别为：
 #testWithDefaultPath--常规测试模式，支持多种读和写操作的混合负载
 #testWithRealDataSet--写入真实数据集模式，需要配置 FILE_PATH 以及 DATA_SET
+#queryWithRealDataSet--查询真实数据集模式，需要配置REAL_QUERY_START_TIME, REAL_QUERY_STOP_TIME,
+# DATA_SET 以及 testWithDefaultPath模式下查询有关参数
 #insertTestWithUserDefinedPath--样例数据生成模式
 #serverMODE--服务器资源使用监控模式（该模式下运行通过ser-benchmark.sh脚本启动，无需手动配置该参数）
 #importDataFromCSV--从CSV文件中读取数据模式
@@ -179,6 +181,10 @@ READ_FROM_FILE=false
 FILE_PATH=data/geolife/
 ### REDD, TDRIVE, GEOLIFE
 DATA_SET=GEOLIFE
+REAL_QUERY_START_TIME=1303132929000
+REAL_QUERY_STOP_TIME=1303132946000
+
+
 TAG_PATH=true
 #1: set each measurement as a storage group, 2: set each path as a storage group
 STORE_MODE=2

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/App.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/App.java
@@ -70,7 +70,7 @@ public class App {
             case Constants.MODE_TEST_WITH_DEFAULT_PATH:
                 testWithDefaultPath(config);
                 break;
-            case Constants.MODE_TEST_WITH_REAL_DATASET:
+            case Constants.MODE_WRITE_WITH_REAL_DATASET:
                 testWithRealDataSet(config);
                 break;
             case Constants.MODE_QUERY_WITH_REAL_DATASET:

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/BaseClient.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/BaseClient.java
@@ -11,7 +11,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import org.slf4j.Logger;
 
-public abstract class SyntheticBaseClient extends Client implements Runnable {
+/**
+ * 负责人造数据的写入、查询，真实数据的查询。
+ * 根据OPERATION_PROPORTION的比例执行写入和查询, 具体的查询和写入数据由workload确定。
+ */
+public abstract class BaseClient extends Client implements Runnable {
 
   protected static Logger LOGGER;
 
@@ -22,7 +26,7 @@ public abstract class SyntheticBaseClient extends Client implements Runnable {
   private DataSchema dataSchema = DataSchema.getInstance();
 
 
-  public SyntheticBaseClient(int id, CountDownLatch countDownLatch, CyclicBarrier barrier,
+  public BaseClient(int id, CountDownLatch countDownLatch, CyclicBarrier barrier,
       IWorkload workload) {
     super(id, countDownLatch, barrier);
     syntheticWorkload = workload;

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/QueryRealDatasetClient.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/QueryRealDatasetClient.java
@@ -1,0 +1,18 @@
+package cn.edu.tsinghua.iotdb.benchmark.client;
+
+import cn.edu.tsinghua.iotdb.benchmark.conf.Config;
+import cn.edu.tsinghua.iotdb.benchmark.workload.RealDatasetWorkLoad;
+import java.util.concurrent.CountDownLatch;
+import org.slf4j.LoggerFactory;
+
+public class QueryRealDatasetClient extends SyntheticBaseClient {
+
+  public QueryRealDatasetClient(int id, CountDownLatch countDownLatch, Config config) {
+    super(id, countDownLatch, new RealDatasetWorkLoad(config));
+  }
+
+  @Override
+  void initLogger() {
+    LOGGER = LoggerFactory.getLogger(QueryRealDatasetClient.class);
+  }
+}

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/QueryRealDatasetClient.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/QueryRealDatasetClient.java
@@ -6,7 +6,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import org.slf4j.LoggerFactory;
 
-public class QueryRealDatasetClient extends SyntheticBaseClient {
+public class QueryRealDatasetClient extends BaseClient {
 
   public QueryRealDatasetClient(int id, CountDownLatch countDownLatch, CyclicBarrier barrier,
       Config config) {

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/SyntheticBaseClient.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/SyntheticBaseClient.java
@@ -1,0 +1,124 @@
+package cn.edu.tsinghua.iotdb.benchmark.client;
+
+import cn.edu.tsinghua.iotdb.benchmark.client.OperationController.Operation;
+import cn.edu.tsinghua.iotdb.benchmark.workload.IWorkload;
+import cn.edu.tsinghua.iotdb.benchmark.workload.SingletonWorkload;
+import cn.edu.tsinghua.iotdb.benchmark.workload.WorkloadException;
+import cn.edu.tsinghua.iotdb.benchmark.workload.schema.DataSchema;
+import cn.edu.tsinghua.iotdb.benchmark.workload.schema.DeviceSchema;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import org.slf4j.Logger;
+
+public abstract class SyntheticBaseClient extends Client implements Runnable {
+
+  protected static Logger LOGGER;
+
+  private OperationController operationController;
+  private IWorkload syntheticWorkload;
+  private final SingletonWorkload singletonWorkload;
+  private long insertLoopIndex;
+  private DataSchema dataSchema = DataSchema.getInstance();
+
+
+  public SyntheticBaseClient(int id, CountDownLatch countDownLatch, IWorkload workload) {
+    super(id, countDownLatch);
+    syntheticWorkload = workload;
+    singletonWorkload = SingletonWorkload.getInstance();
+    operationController = new OperationController(id);
+    insertLoopIndex = 0;
+    initLogger();
+  }
+
+  void doTest() {
+    for (long loopIndex = 0; loopIndex < config.LOOP; loopIndex++) {
+      Operation operation = operationController.getNextOperationType();
+      switch (operation) {
+        case INGESTION:
+          if (config.IS_CLIENT_BIND) {
+            try {
+              List<DeviceSchema> schema = dataSchema.getClientBindSchema().get(clientThreadId);
+              for (DeviceSchema deviceSchema : schema) {
+                dbWrapper
+                    .insertOneBatch(syntheticWorkload.getOneBatch(deviceSchema, insertLoopIndex));
+              }
+            } catch (Exception e) {
+              LOGGER.error("Failed to insert one batch data because ", e);
+            }
+            insertLoopIndex++;
+          } else {
+            try {
+              dbWrapper.insertOneBatch(singletonWorkload.getOneBatch());
+            } catch (Exception e) {
+              LOGGER.error("Failed to insert one batch data because ", e);
+            }
+          }
+          break;
+        case PRECISE_QUERY:
+          try {
+            dbWrapper.preciseQuery(syntheticWorkload.getPreciseQuery());
+          } catch (Exception e) {
+            LOGGER.error("Failed to do precise query because ", e);
+          }
+          break;
+        case RANGE_QUERY:
+          try {
+            dbWrapper.rangeQuery(syntheticWorkload.getRangeQuery());
+          } catch (Exception e) {
+            LOGGER.error("Failed to do range query because ", e);
+          }
+          break;
+        case VALUE_RANGE_QUERY:
+          try {
+            dbWrapper.valueRangeQuery(syntheticWorkload.getValueRangeQuery());
+          } catch (WorkloadException e) {
+            LOGGER.error("Failed to do range query with value filter because ", e);
+          }
+          break;
+        case AGG_RANGE_QUERY:
+          try {
+            dbWrapper.aggRangeQuery(syntheticWorkload.getAggRangeQuery());
+          } catch (WorkloadException e) {
+            LOGGER.error("Failed to do aggregation range query because ", e);
+          }
+          break;
+        case AGG_VALUE_QUERY:
+          try {
+            dbWrapper.aggValueQuery(syntheticWorkload.getAggValueQuery());
+          } catch (WorkloadException e) {
+            LOGGER.error("Failed to do aggregation query with value filter because ", e);
+          }
+          break;
+        case AGG_RANGE_VALUE_QUERY:
+          try {
+            dbWrapper.aggRangeValueQuery(syntheticWorkload.getAggRangeValueQuery());
+          } catch (WorkloadException e) {
+            LOGGER.error("Failed to do aggregation range query with value filter because ", e);
+          }
+          break;
+        case GROUP_BY_QUERY:
+          try {
+            dbWrapper.groupByQuery(syntheticWorkload.getGroupByQuery());
+          } catch (WorkloadException e) {
+            LOGGER.error("Failed to do group by query because ", e);
+          }
+          break;
+        case LATEST_POINT_QUERY:
+          try {
+            dbWrapper.latestPointQuery(syntheticWorkload.getLatestPointQuery());
+          } catch (WorkloadException e) {
+            LOGGER.error("Failed to do latest point query because ", e);
+          }
+          break;
+        default:
+          LOGGER.error("Unsupported operation type {}", operation);
+      }
+      String percent = String.format("%.2f", (loopIndex + 1) * 100.0D / config.LOOP);
+      LOGGER.info("{} {}% syntheticWorkload is done.", Thread.currentThread().getName(), percent);
+    }
+  }
+
+  abstract void initLogger();
+
+}
+

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/SyntheticClient.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/SyntheticClient.java
@@ -5,7 +5,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import org.slf4j.LoggerFactory;
 
-public class SyntheticClient extends SyntheticBaseClient {
+public class SyntheticClient extends BaseClient {
 
   public SyntheticClient(int id, CountDownLatch countDownLatch, CyclicBarrier barrier) {
     super(id, countDownLatch, barrier, new SyntheticWorkload(id));

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/SyntheticClient.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/SyntheticClient.java
@@ -1,120 +1,17 @@
 package cn.edu.tsinghua.iotdb.benchmark.client;
 
-import cn.edu.tsinghua.iotdb.benchmark.client.OperationController.Operation;
-import cn.edu.tsinghua.iotdb.benchmark.workload.SingletonWorkload;
 import cn.edu.tsinghua.iotdb.benchmark.workload.SyntheticWorkload;
-import cn.edu.tsinghua.iotdb.benchmark.workload.WorkloadException;
-import cn.edu.tsinghua.iotdb.benchmark.workload.schema.DataSchema;
-import cn.edu.tsinghua.iotdb.benchmark.workload.schema.DeviceSchema;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SyntheticClient extends Client implements Runnable {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(SyntheticClient.class);
-
-  private OperationController operationController;
-  private SyntheticWorkload syntheticWorkload;
-  private final SingletonWorkload singletonWorkload;
-  private long insertLoopIndex;
-  private DataSchema dataSchema = DataSchema.getInstance();
-
+public class SyntheticClient extends SyntheticBaseClient {
 
   public SyntheticClient(int id, CountDownLatch countDownLatch) {
-    super(id, countDownLatch);
-    syntheticWorkload = new SyntheticWorkload(id);
-    singletonWorkload = SingletonWorkload.getInstance();
-    operationController = new OperationController(id);
-    insertLoopIndex = 0;
+    super(id, countDownLatch, new SyntheticWorkload(id));
   }
 
-  void doTest() {
-    for (long loopIndex = 0; loopIndex < config.LOOP; loopIndex++) {
-      Operation operation = operationController.getNextOperationType();
-      switch (operation) {
-        case INGESTION:
-          if (config.IS_CLIENT_BIND) {
-            try {
-              List<DeviceSchema> schema = dataSchema.getClientBindSchema().get(clientThreadId);
-              for (DeviceSchema deviceSchema : schema) {
-                dbWrapper.insertOneBatch(syntheticWorkload.getOneBatch(deviceSchema, insertLoopIndex));
-              }
-            } catch (Exception e) {
-              LOGGER.error("Failed to insert one batch data because ", e);
-            }
-            insertLoopIndex++;
-          } else {
-            try {
-              dbWrapper.insertOneBatch(singletonWorkload.getOneBatch());
-            } catch (Exception e) {
-              LOGGER.error("Failed to insert one batch data because ", e);
-            }
-          }
-          break;
-        case PRECISE_QUERY:
-          try {
-            dbWrapper.preciseQuery(syntheticWorkload.getPreciseQuery());
-          } catch (Exception e) {
-            LOGGER.error("Failed to do precise query because ", e);
-          }
-          break;
-        case RANGE_QUERY:
-          try {
-            dbWrapper.rangeQuery(syntheticWorkload.getRangeQuery());
-          } catch (Exception e) {
-            LOGGER.error("Failed to do range query because ", e);
-          }
-          break;
-        case VALUE_RANGE_QUERY:
-          try {
-            dbWrapper.valueRangeQuery(syntheticWorkload.getValueRangeQuery());
-          } catch (WorkloadException e) {
-            LOGGER.error("Failed to do range query with value filter because ", e);
-          }
-          break;
-        case AGG_RANGE_QUERY:
-          try {
-            dbWrapper.aggRangeQuery(syntheticWorkload.getAggRangeQuery());
-          } catch (WorkloadException e) {
-            LOGGER.error("Failed to do aggregation range query because ", e);
-          }
-          break;
-        case AGG_VALUE_QUERY:
-          try {
-            dbWrapper.aggValueQuery(syntheticWorkload.getAggValueQuery());
-          } catch (WorkloadException e) {
-            LOGGER.error("Failed to do aggregation query with value filter because ", e);
-          }
-          break;
-        case AGG_RANGE_VALUE_QUERY:
-          try {
-            dbWrapper.aggRangeValueQuery(syntheticWorkload.getAggRangeValueQuery());
-          } catch (WorkloadException e) {
-            LOGGER.error("Failed to do aggregation range query with value filter because ", e);
-          }
-          break;
-        case GROUP_BY_QUERY:
-          try {
-            dbWrapper.groupByQuery(syntheticWorkload.getGroupByQuery());
-          } catch (WorkloadException e) {
-            LOGGER.error("Failed to do group by query because ", e);
-          }
-          break;
-        case LATEST_POINT_QUERY:
-          try {
-            dbWrapper.latestPointQuery(syntheticWorkload.getLatestPointQuery());
-          } catch (WorkloadException e) {
-            LOGGER.error("Failed to do latest point query because ", e);
-          }
-          break;
-        default:
-          LOGGER.error("Unsupported operation type {}", operation);
-      }
-      String percent = String.format("%.2f", (loopIndex + 1) * 100.0D / config.LOOP);
-      LOGGER.info("{} {}% syntheticWorkload is done.", Thread.currentThread().getName(), percent);
-    }
+  @Override
+  void initLogger() {
+    LOGGER = LoggerFactory.getLogger(SyntheticClient.class);
   }
-
 }

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
@@ -188,6 +188,8 @@ public class Config {
 	public int QUERY_SLIMIT_N = 1;
 	public int QUERY_SLIMIT_OFFSET = 0;
 	public boolean CREATE_SCHEMA = true;
+	public long REAL_QUERY_START_TIME = 0;
+	public long REAL_QUERY_STOP_TIME = Long.MAX_VALUE;
 
 	//mysql相关参数
 	// mysql服务器URL以及用户名密码

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
@@ -145,6 +145,8 @@ public class ConfigDescriptor {
 				config.STEP_SIZE = Integer.parseInt(properties.getProperty("STEP_SIZE", config.STEP_SIZE+""));
 				config.IS_CLIENT_BIND = Boolean.parseBoolean(properties.getProperty("IS_CLIENT_BIND", config.IS_CLIENT_BIND+""));
 				config.IS_DELETE_DATA = Boolean.parseBoolean(properties.getProperty("IS_DELETE_DATA", config.IS_DELETE_DATA+""));
+				config.REAL_QUERY_START_TIME = Long.parseLong(properties.getProperty("REAL_QUERY_START_TIME", config.REAL_QUERY_START_TIME+""));
+        config.REAL_QUERY_STOP_TIME = Long.parseLong(properties.getProperty("REAL_QUERY_STOP_TIME", config.REAL_QUERY_STOP_TIME+""));
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Constants.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Constants.java
@@ -49,6 +49,7 @@ public class Constants {
     //different running mode
     public static final String MODE_IMPORT_DATA_FROM_CSV = "importDataFromCSV";
     public static final String MODE_TEST_WITH_REAL_DATASET = "testWithRealDataSet";
+    public static final String MODE_QUERY_WITH_REAL_DATASET = "queryWithRealDataSet";
     public static final String MODE_QUERY_TEST_WITH_DEFAULT_PATH = "queryTestWithDefaultPath";
     public static final String MODE_INSERT_TEST_WITH_DEFAULT_PATH = "insertTestWithDefaultPath";
     public static final String MODE_TEST_WITH_DEFAULT_PATH = "testWithDefaultPath";

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Constants.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Constants.java
@@ -48,7 +48,7 @@ public class Constants {
     public static final String SAMPLE_DATA_FILE_NAME = "sampleData.txt";
     //different running mode
     public static final String MODE_IMPORT_DATA_FROM_CSV = "importDataFromCSV";
-    public static final String MODE_TEST_WITH_REAL_DATASET = "testWithRealDataSet";
+    public static final String MODE_WRITE_WITH_REAL_DATASET = "writeWithRealDataSet";
     public static final String MODE_QUERY_WITH_REAL_DATASET = "queryWithRealDataSet";
     public static final String MODE_QUERY_TEST_WITH_DEFAULT_PATH = "queryTestWithDefaultPath";
     public static final String MODE_INSERT_TEST_WITH_DEFAULT_PATH = "insertTestWithDefaultPath";

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/IWorkload.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/IWorkload.java
@@ -11,8 +11,7 @@ import cn.edu.tsinghua.iotdb.benchmark.workload.query.impl.RangeQuery;
 import cn.edu.tsinghua.iotdb.benchmark.workload.query.impl.ValueRangeQuery;
 import cn.edu.tsinghua.iotdb.benchmark.workload.schema.DeviceSchema;
 
-//TODO not used yet
-interface IWorkload {
+public interface IWorkload {
 
   Batch getOneBatch(DeviceSchema deviceSchema, long loopIndex) throws WorkloadException;
 
@@ -20,16 +19,16 @@ interface IWorkload {
 
   RangeQuery getRangeQuery() throws WorkloadException;
 
-  ValueRangeQuery getValueRangeQuery();
+  ValueRangeQuery getValueRangeQuery() throws WorkloadException;
 
-  AggRangeQuery getAggRangeQuery();
+  AggRangeQuery getAggRangeQuery() throws WorkloadException;
 
-  AggValueQuery getAggValueQuery();
+  AggValueQuery getAggValueQuery() throws WorkloadException;
 
-  AggRangeValueQuery getAggRangeValueQuery();
+  AggRangeValueQuery getAggRangeValueQuery() throws WorkloadException;
 
-  GroupByQuery getGroupByQuery();
+  GroupByQuery getGroupByQuery() throws WorkloadException;
 
-  LatestPointQuery getLatestPointQuery();
+  LatestPointQuery getLatestPointQuery() throws WorkloadException;
 
 }

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/RealDatasetWorkLoad.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/RealDatasetWorkLoad.java
@@ -24,8 +24,8 @@ public class RealDatasetWorkLoad implements IWorkload {
 
   private Config config;
   private List<DeviceSchema> deviceSchemaList;
-  private long st;
-  private long et;
+  private long startTime;
+  private long endTime;
 
   /**
    * write test.
@@ -73,8 +73,8 @@ public class RealDatasetWorkLoad implements IWorkload {
     }
 
     //init startTime, endTime
-    st = config.REAL_QUERY_START_TIME;
-    et = config.REAL_QUERY_STOP_TIME;
+    startTime = config.REAL_QUERY_START_TIME;
+    endTime = config.REAL_QUERY_STOP_TIME;
 
   }
 
@@ -93,22 +93,22 @@ public class RealDatasetWorkLoad implements IWorkload {
 
   @Override
   public PreciseQuery getPreciseQuery() {
-    return new PreciseQuery(deviceSchemaList, st);
+    return new PreciseQuery(deviceSchemaList, startTime);
   }
 
   @Override
   public RangeQuery getRangeQuery() {
-    return new RangeQuery(deviceSchemaList, st, et);
+    return new RangeQuery(deviceSchemaList, startTime, endTime);
   }
 
   @Override
   public ValueRangeQuery getValueRangeQuery() {
-    return new ValueRangeQuery(deviceSchemaList, st, et, config.QUERY_LOWER_LIMIT);
+    return new ValueRangeQuery(deviceSchemaList, startTime, endTime, config.QUERY_LOWER_LIMIT);
   }
 
   @Override
   public AggRangeQuery getAggRangeQuery() {
-    return new AggRangeQuery(deviceSchemaList, st, et, config.QUERY_AGGREGATE_FUN);
+    return new AggRangeQuery(deviceSchemaList, startTime, endTime, config.QUERY_AGGREGATE_FUN);
   }
 
   @Override
@@ -119,19 +119,19 @@ public class RealDatasetWorkLoad implements IWorkload {
 
   @Override
   public AggRangeValueQuery getAggRangeValueQuery() {
-    return new AggRangeValueQuery(deviceSchemaList, st, et, config.QUERY_AGGREGATE_FUN,
+    return new AggRangeValueQuery(deviceSchemaList, startTime, endTime, config.QUERY_AGGREGATE_FUN,
         config.QUERY_LOWER_LIMIT);
   }
 
   @Override
   public GroupByQuery getGroupByQuery() {
-    return new GroupByQuery(deviceSchemaList, st, et, config.QUERY_AGGREGATE_FUN,
+    return new GroupByQuery(deviceSchemaList, startTime, endTime, config.QUERY_AGGREGATE_FUN,
         config.QUERY_INTERVAL);
   }
 
   @Override
   public LatestPointQuery getLatestPointQuery() {
-    return new LatestPointQuery(deviceSchemaList, st, et, "last");
+    return new LatestPointQuery(deviceSchemaList, startTime, endTime, "last");
   }
 
   static String calGroupIdStr(String deviceId, int groupNum) {

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/RealDatasetWorkLoad.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/RealDatasetWorkLoad.java
@@ -14,12 +14,25 @@ import cn.edu.tsinghua.iotdb.benchmark.workload.reader.BasicReader;
 import cn.edu.tsinghua.iotdb.benchmark.workload.reader.GeolifeReader;
 import cn.edu.tsinghua.iotdb.benchmark.workload.reader.ReddReader;
 import cn.edu.tsinghua.iotdb.benchmark.workload.reader.TDriveReader;
+import cn.edu.tsinghua.iotdb.benchmark.workload.schema.DeviceSchema;
+import java.util.ArrayList;
 import java.util.List;
 
-public class RealDatasetWorkLoad{
+public class RealDatasetWorkLoad implements IWorkload {
 
   private BasicReader reader;
 
+  private Config config;
+  private List<DeviceSchema> deviceSchemaList;
+  private long st;
+  private long et;
+
+  /**
+   * write test.
+   *
+   * @param files real dataset files
+   * @param config config
+   */
   public RealDatasetWorkLoad(List<String> files, Config config) {
     switch (config.DATA_SET) {
       case TDRIVE:
@@ -36,43 +49,93 @@ public class RealDatasetWorkLoad{
     }
   }
 
+  /**
+   * read test.
+   *
+   * @param config config
+   */
+  public RealDatasetWorkLoad(Config config) {
+    this.config = config;
+
+    //init sensor list
+    List<String> sensorList = new ArrayList<>();
+    for (int i = 0; i < config.QUERY_SENSOR_NUM; i++) {
+      sensorList.add(config.FIELDS.get(i));
+    }
+
+    //init device schema list
+    deviceSchemaList = new ArrayList<>();
+    for (int i = 1; i <= config.QUERY_DEVICE_NUM; i++) {
+      String deviceIdStr = "" + i;
+      DeviceSchema deviceSchema = new DeviceSchema(calGroupIdStr(deviceIdStr, config.GROUP_NUMBER),
+          deviceIdStr, sensorList);
+      deviceSchemaList.add(deviceSchema);
+    }
+
+    //init startTime, endTime
+    st = config.REAL_QUERY_START_TIME;
+    et = config.REAL_QUERY_STOP_TIME;
+
+  }
+
   public Batch getOneBatch() {
-    if(reader.hasNextBatch()) {
+    if (reader.hasNextBatch()) {
       return reader.nextBatch();
     } else {
       return null;
     }
   }
 
-  public PreciseQuery getPreciseQuery() throws WorkloadException {
-    return null;
+  @Override
+  public Batch getOneBatch(DeviceSchema deviceSchema, long loopIndex) throws WorkloadException {
+    throw new WorkloadException("not support in real data workload.");
   }
 
-  public RangeQuery getRangeQuery() throws WorkloadException {
-    return null;
+  @Override
+  public PreciseQuery getPreciseQuery() {
+    return new PreciseQuery(deviceSchemaList, st);
   }
 
+  @Override
+  public RangeQuery getRangeQuery() {
+    return new RangeQuery(deviceSchemaList, st, et);
+  }
+
+  @Override
   public ValueRangeQuery getValueRangeQuery() {
-    return null;
+    return new ValueRangeQuery(deviceSchemaList, st, et, config.QUERY_LOWER_LIMIT);
   }
 
+  @Override
   public AggRangeQuery getAggRangeQuery() {
-    return null;
+    return new AggRangeQuery(deviceSchemaList, st, et, config.QUERY_AGGREGATE_FUN);
   }
 
+  @Override
   public AggValueQuery getAggValueQuery() {
-    return null;
+    return new AggValueQuery(deviceSchemaList, config.QUERY_AGGREGATE_FUN,
+        config.QUERY_LOWER_LIMIT);
   }
 
+  @Override
   public AggRangeValueQuery getAggRangeValueQuery() {
-    return null;
+    return new AggRangeValueQuery(deviceSchemaList, st, et, config.QUERY_AGGREGATE_FUN,
+        config.QUERY_LOWER_LIMIT);
   }
 
+  @Override
   public GroupByQuery getGroupByQuery() {
-    return null;
+    return new GroupByQuery(deviceSchemaList, st, et, config.QUERY_AGGREGATE_FUN,
+        config.QUERY_INTERVAL);
   }
 
+  @Override
   public LatestPointQuery getLatestPointQuery() {
-    return null;
+    return new LatestPointQuery(deviceSchemaList, st, et, "last");
   }
+
+  static String calGroupIdStr(String deviceId, int groupNum) {
+    return String.valueOf(deviceId.hashCode() % groupNum);
+  }
+
 }

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/SyntheticWorkload.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/SyntheticWorkload.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-public class SyntheticWorkload {
+public class SyntheticWorkload implements IWorkload {
 
   private static Config config = ConfigDescriptor.getInstance().getConfig();
   private static Random timestampRandom = new Random(config.DATA_SEED);


### PR DESCRIPTION
实现了真实数据集的查询负载，在testWithDefaultPath模式下，每个客户端会执行LOOP次查询，每种查询的查询条件相同：
>需要配置REAL_QUERY_START_TIME, REAL_QUERY_STOP_TIME做为时间范围, DATA_SET 以及 testWithDefaultPath模式下查询有关参数。
>在testWithDefaultPath模式下,设备的名字是1，2，3....
>OPERATION_PROPORTION=2:0:0:0:0:0:0:0:0中的写入比例必须为0，有参数检查


执行结果：
>写入REDD数据集的2个设备，每个设备18个点
<img width="847" alt="image" src="https://user-images.githubusercontent.com/13203019/56571137-e596d500-65ee-11e9-8a77-1cd11ff63243.png">

>查询单timeseries
<img width="847" alt="image" src="https://user-images.githubusercontent.com/13203019/56571087-cbf58d80-65ee-11e9-9371-b588107690af.png">