### PR TITLE
balance workload among multiple client.

### DIFF
--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DataSchema.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DataSchema.java
@@ -33,24 +33,24 @@ public class DataSchema {
 
   private void createClientBindSchema() {
     int eachClientDeviceNum = 0;
-    if(config.CLIENT_NUMBER!=0) {
+    if (config.CLIENT_NUMBER != 0) {
       eachClientDeviceNum = config.DEVICE_NUMBER / config.CLIENT_NUMBER;
     } else {
       LOGGER.error("CLIENT_NUMBER can not be zero.");
       return;
     }
+
+    int deviceId = 0;
+    int mod = config.DEVICE_NUMBER % config.CLIENT_NUMBER;
     for (int clientId = 0; clientId < config.CLIENT_NUMBER - 1; clientId++) {
       List<DeviceSchema> deviceSchemaList = new ArrayList<>();
-      for (int i = clientId * eachClientDeviceNum; i < (clientId + 1) * eachClientDeviceNum; i++) {
-        deviceSchemaList.add(new DeviceSchema(i));
+      for (int j = 0; j < eachClientDeviceNum; j++) {
+        deviceSchemaList.add(new DeviceSchema(deviceId++));
+      }
+      if (clientId < mod) {
+        deviceSchemaList.add(new DeviceSchema(deviceId++));
       }
       CLIENT_BIND_SCHEMA.put(clientId, deviceSchemaList);
     }
-    // get the schema of the last client
-    List<DeviceSchema> lastDeviceSchemaList = new ArrayList<>();
-    for (int i = (config.CLIENT_NUMBER - 1) * eachClientDeviceNum; i < config.DEVICE_NUMBER; i++) {
-      lastDeviceSchemaList.add(new DeviceSchema(i));
-    }
-    CLIENT_BIND_SCHEMA.put(config.CLIENT_NUMBER - 1, lastDeviceSchemaList);
   }
 }

--- a/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DeviceSchema.java
+++ b/src/main/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DeviceSchema.java
@@ -46,21 +46,27 @@ public class DeviceSchema {
 
 
   private void createEvenlyAllocDeviceSchema() throws WorkloadException {
-    if (config.GROUP_NUMBER > config.DEVICE_NUMBER) {
-      throw new WorkloadException("DEVICE_NUMBER must less than or equal to GROUP_NUMBER.");
-    }
-    int eachGroupDeviceNum = config.DEVICE_NUMBER / config.GROUP_NUMBER;
-    int thisDeviceGroupIndex = deviceId / eachGroupDeviceNum;
-    if (deviceId >= eachGroupDeviceNum * config.GROUP_NUMBER) {
-      thisDeviceGroupIndex = config.GROUP_NUMBER - 1;
-    }
-    if (thisDeviceGroupIndex < 0) {
-      throw new WorkloadException("DEVICE_NUMBER and GROUP_NUMBER must be positive.");
-    }
+    int thisDeviceGroupIndex = calGroupId(deviceId, config.DEVICE_NUMBER, config.GROUP_NUMBER);
+
     group = GROUP_NAME_PREFIX + thisDeviceGroupIndex;
     sensors.addAll(config.SENSOR_CODES);
   }
 
+  static int calGroupId(int deviceId, int deviceNum, int groupNum) throws WorkloadException {
+    int eachGroupDeviceNum = deviceNum / groupNum;
+    int mod = deviceNum % groupNum;
+    int thisDeviceGroupIndex;
+    if (deviceId < (eachGroupDeviceNum + 1) * mod) {
+      thisDeviceGroupIndex = deviceId / (eachGroupDeviceNum + 1);
+    } else {
+      thisDeviceGroupIndex = (deviceId - mod) / eachGroupDeviceNum;
+    }
+
+    if (thisDeviceGroupIndex < 0) {
+      throw new WorkloadException("DEVICE_NUMBER and GROUP_NUMBER must be positive.");
+    }
+    return thisDeviceGroupIndex;
+  }
 
   public String getDevice() {
     return device;

--- a/src/test/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DataSchemaTest.java
+++ b/src/test/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DataSchemaTest.java
@@ -1,0 +1,38 @@
+package cn.edu.tsinghua.iotdb.benchmark.workload.schema;
+
+import cn.edu.tsinghua.iotdb.benchmark.conf.Config;
+import cn.edu.tsinghua.iotdb.benchmark.conf.ConfigDescriptor;
+import java.util.List;
+import java.util.Map;
+import javax.xml.crypto.dsig.keyinfo.KeyValue;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DataSchemaTest {
+  private static Config config = ConfigDescriptor.getInstance().getConfig();
+  @Test
+  public void test(){
+    testBalanceSplit(100, 30);
+
+  }
+
+  void testBalanceSplit(int deviceNum, int clientNum){
+    config.DEVICE_NUMBER = deviceNum;
+    config.CLIENT_NUMBER = clientNum;
+    int mod = config.DEVICE_NUMBER % config.CLIENT_NUMBER;
+    int deviceNumEachClient = config.DEVICE_NUMBER / config.CLIENT_NUMBER;
+    DataSchema dataSchema = DataSchema.getInstance();
+    Map<Integer, List<DeviceSchema>> client2Schema = dataSchema.getClientBindSchema();
+    for (int clientId : client2Schema.keySet()){
+      int deviceNumInClient = client2Schema.get(clientId).size();
+      if ( clientId < mod){
+        Assert.assertEquals(deviceNumEachClient+1,deviceNumInClient);
+      }
+      else {
+        Assert.assertEquals(deviceNumEachClient,deviceNumInClient);
+      }
+    }
+  }
+
+
+}

--- a/src/test/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DataSchemaTest.java
+++ b/src/test/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DataSchemaTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 public class DataSchemaTest {
   private static Config config = ConfigDescriptor.getInstance().getConfig();
+
   @Test
   public void test(){
     testBalanceSplit(100, 30);
@@ -17,6 +18,8 @@ public class DataSchemaTest {
   }
 
   void testBalanceSplit(int deviceNum, int clientNum){
+    int preDeviceNum = config.DEVICE_NUMBER;
+    int preClientNum = config.CLIENT_NUMBER;
     config.DEVICE_NUMBER = deviceNum;
     config.CLIENT_NUMBER = clientNum;
     int mod = config.DEVICE_NUMBER % config.CLIENT_NUMBER;
@@ -32,6 +35,8 @@ public class DataSchemaTest {
         Assert.assertEquals(deviceNumEachClient,deviceNumInClient);
       }
     }
+    config.DEVICE_NUMBER = preDeviceNum;
+    config.CLIENT_NUMBER = preClientNum;
   }
 
 

--- a/src/test/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DeviceSchemaTest.java
+++ b/src/test/java/cn/edu/tsinghua/iotdb/benchmark/workload/schema/DeviceSchemaTest.java
@@ -1,12 +1,7 @@
 package cn.edu.tsinghua.iotdb.benchmark.workload.schema;
 
 import static org.junit.Assert.assertEquals;
-
-import cn.edu.tsinghua.iotdb.benchmark.conf.Config;
-import cn.edu.tsinghua.iotdb.benchmark.conf.ConfigDescriptor;
 import org.junit.Test;
-import org.junit.Before; 
-import org.junit.After; 
 
 /** 
 * DeviceSchema Tester. 
@@ -16,109 +11,24 @@ import org.junit.After;
 * @version 1.0 
 */ 
 public class DeviceSchemaTest {
-  private static Config config = ConfigDescriptor.getInstance().getConfig();
-
-@Before
-public void before() throws Exception { 
-} 
-
-@After
-public void after() throws Exception { 
-} 
-
 /** 
 * 
-* Method: getDeviceId() 
+* Method: CalGroupId()
 * 
 */ 
 @Test
-public void testGetDeviceId() throws Exception { 
-//TODO: Test goes here... 
-} 
+public void testCalGroupId() throws Exception {
+  int g1 = DeviceSchema.calGroupId(4, 10, 3);
+  assertEquals(1,g1 );
+  int g2 = DeviceSchema.calGroupId(3, 10, 3);
+  assertEquals(0, g2);
 
-/** 
-* 
-* Method: setDeviceId(int deviceId) 
-* 
-*/ 
-@Test
-public void testSetDeviceId() throws Exception { 
-//TODO: Test goes here... 
-} 
-
-/** 
-* 
-* Method: getDevice() 
-* 
-*/ 
-@Test
-public void testGetDevice() throws Exception { 
-//TODO: Test goes here... 
-} 
-
-/** 
-* 
-* Method: setDevice(String device) 
-* 
-*/ 
-@Test
-public void testSetDevice() throws Exception { 
-//TODO: Test goes here... 
-} 
-
-/** 
-* 
-* Method: getGroup() 
-* 
-*/ 
-@Test
-public void testGetGroup() throws Exception { 
-//TODO: Test goes here... 
-} 
-
-/** 
-* 
-* Method: setGroup(String group) 
-* 
-*/ 
-@Test
-public void testSetGroup() throws Exception { 
-//TODO: Test goes here... 
-} 
-
-/** 
-* 
-* Method: getSensors() 
-* 
-*/ 
-@Test
-public void testGetSensors() throws Exception { 
-//TODO: Test goes here... 
-} 
-
-/** 
-* 
-* Method: setSensors(List<String> sensors) 
-* 
-*/ 
-@Test
-public void testSetSensors() throws Exception { 
-//TODO: Test goes here... 
-} 
-
-
-/** 
-* 
-* Method: createEvenlyAllocDeviceSchema() 
-* 
-*/ 
-@Test
-public void testCreateEvenlyAllocDeviceSchema() throws Exception { 
-  config.DEVICE_NUMBER = 10;
-  config.GROUP_NUMBER = 3;
-  DeviceSchema deviceSchema = new DeviceSchema(4);
-  assertEquals("group_1", deviceSchema.getGroup());
-  assertEquals("d_4", deviceSchema.getDevice());
+  int g3 = DeviceSchema.calGroupId(30, 100, 30);
+  assertEquals(7, g3);
+  int g4 = DeviceSchema.calGroupId(40, 100, 30);
+  assertEquals(10, g4);
+  int g5 = DeviceSchema.calGroupId(0, 1, 3);
+  assertEquals(0, g5);
 } 
 
 } 


### PR DESCRIPTION
若设置参数IS_CLIENT_BIND=true，则每个客户端只负责某几个设备的写入负载，且每个设备的写入负载仅分配给一个客户端：
> 在之前的实现中,若DEVICE_NUM不能被CLIENT_NUM整除，则剩下的余数个DEVICE全部分配给最后一个client，造成client之间负载不平衡的现象。而写入时间统计的是最后一个客户端的完成时间，这样当设备数不能被客户端数目整除的时候，测试结果不准。
> 此pr调整了设备和客户端之间的对应策略，不管设备数能否被客户端数目整除，均保证不同的客户端负责写入的设备数目最多相差1个。