### PR TITLE
The timestamp precision for test results has been changed from millis…

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -212,6 +212,7 @@ WORKLOAD_BUFFER_SIZE=100
 #################### 输出结果配置 ########################
 ########################################################
 # 结果持久化选择，支持None，IoTDB，MySQL和CSV
+# 选择IoTDB，请设置IoTDB的timestamp_precision=ns
 TEST_DATA_PERSISTENCE=IoTDB
 
 ############## 输出结果：输出数据库参数 ####################


### PR DESCRIPTION
1.The timestamp accuracy for recording test results has been changed from milliseconds to nanoseconds
测试结果写到iotdb，此iotdb的时间戳精度若为ms，会出现多用户并发时间戳覆盖丢结果的问题，改为ms*1000000+threadID
单位为纳秒
2.Add comments to config.properties