### PR TITLE
optimize IoTDB's cleanup

### DIFF
--- a/iotdb-0.11/src/main/java/cn/edu/tsinghua/iotdb/benchmark/iotdb011/IoTDB.java
+++ b/iotdb-0.11/src/main/java/cn/edu/tsinghua/iotdb/benchmark/iotdb011/IoTDB.java
@@ -60,7 +60,7 @@ public class IoTDB implements IDatabase {
   public IoTDB(DBConfig dbConfig) {
     this.dbConfig = dbConfig;
     ROOT_SERIES_NAME = "root." + dbConfig.getDB_NAME();
-    DELETE_SERIES_SQL = "delete timeseries root." + dbConfig.getDB_NAME();
+    DELETE_SERIES_SQL = "delete storage group root." + dbConfig.getDB_NAME();
   }
 
   @Override

--- a/iotdb-0.12/src/main/java/cn/edu/tsinghua/iotdb/benchmark/iotdb012/IoTDB.java
+++ b/iotdb-0.12/src/main/java/cn/edu/tsinghua/iotdb/benchmark/iotdb012/IoTDB.java
@@ -67,7 +67,7 @@ public class IoTDB implements IDatabase {
   public IoTDB(DBConfig dbConfig) {
     this.dbConfig = dbConfig;
     ROOT_SERIES_NAME = "root." + dbConfig.getDB_NAME();
-    DELETE_SERIES_SQL = "delete timeseries root." + dbConfig.getDB_NAME();
+    DELETE_SERIES_SQL = "delete storage group root." + dbConfig.getDB_NAME();
   }
 
   @Override


### PR DESCRIPTION
For IoTDB, current cleanup method is implemented by "delete timeseries root.test"
When there are many timeseries already exist in db after a round of insertion test, this cleanup method will block many many minutes.
Because In IoTDB, "delete timeseries" is implemented by delete all timeseries of all storage groups, not the storage group itself, which will create a modfile for every tsfile.  These modfiles will be merged on compaction tasks.

This PR will fix this by using "delete storage group"  instead of "delete timeseries".
 