### PR TITLE
Remove useless parameters

### DIFF
--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -234,14 +234,6 @@ QUERY_LOWER_VALUE=-5
 GROUP_BY_TIME_UNIT=20000
 # 查询语句的随机数种子
 QUERY_SEED=151658
-# 条件查询中结果输出项的最大数量
-QUERY_LIMIT_N=5
-# 条件查询中含有Limit子句的偏移量
-QUERY_LIMIT_OFFSET=5
-# 条件查询结果输出序列的最大数量
-QUERY_SLIMIT_N=5
-# 条件查询结果输出序列的偏移量
-QUERY_SLIMIT_OFFSET=5
 
 ################ Workload：相关参数 ######################
 # workload的缓冲区的大小

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
@@ -295,14 +295,6 @@ public class Config {
   private long GROUP_BY_TIME_UNIT = QUERY_INTERVAL / 2;
   /** Query random seed */
   private long QUERY_SEED = 1516580959202L;
-  /** Maximum number of output items in conditional query with limit */
-  private int QUERY_LIMIT_N = 1;
-  /** The offset in conditional query with limit */
-  private int QUERY_LIMIT_OFFSET = 0;
-  /** Maximum number of output sequences */
-  private int QUERY_SLIMIT_N = 1;
-  /** Offset of output sequences */
-  private int QUERY_SLIMIT_OFFSET = 0;
 
   // workload 相关部分
   /** The size of workload buffer size */
@@ -1110,38 +1102,6 @@ public class Config {
     this.QUERY_SEED = QUERY_SEED;
   }
 
-  public int getQUERY_LIMIT_N() {
-    return QUERY_LIMIT_N;
-  }
-
-  public void setQUERY_LIMIT_N(int QUERY_LIMIT_N) {
-    this.QUERY_LIMIT_N = QUERY_LIMIT_N;
-  }
-
-  public int getQUERY_LIMIT_OFFSET() {
-    return QUERY_LIMIT_OFFSET;
-  }
-
-  public void setQUERY_LIMIT_OFFSET(int QUERY_LIMIT_OFFSET) {
-    this.QUERY_LIMIT_OFFSET = QUERY_LIMIT_OFFSET;
-  }
-
-  public int getQUERY_SLIMIT_N() {
-    return QUERY_SLIMIT_N;
-  }
-
-  public void setQUERY_SLIMIT_N(int QUERY_SLIMIT_N) {
-    this.QUERY_SLIMIT_N = QUERY_SLIMIT_N;
-  }
-
-  public int getQUERY_SLIMIT_OFFSET() {
-    return QUERY_SLIMIT_OFFSET;
-  }
-
-  public void setQUERY_SLIMIT_OFFSET(int QUERY_SLIMIT_OFFSET) {
-    this.QUERY_SLIMIT_OFFSET = QUERY_SLIMIT_OFFSET;
-  }
-
   public int getWORKLOAD_BUFFER_SIZE() {
     return WORKLOAD_BUFFER_SIZE;
   }
@@ -1498,14 +1458,6 @@ public class Config {
         + GROUP_BY_TIME_UNIT
         + "\nQUERY_SEED="
         + QUERY_SEED
-        + "\nQUERY_LIMIT_N="
-        + QUERY_LIMIT_N
-        + "\nQUERY_LIMIT_OFFSET="
-        + QUERY_LIMIT_OFFSET
-        + "\nQUERY_SLIMIT_N="
-        + QUERY_SLIMIT_N
-        + "\nQUERY_SLIMIT_OFFSET="
-        + QUERY_SLIMIT_OFFSET
         + "\nWORKLOAD_BUFFER_SIZE="
         + WORKLOAD_BUFFER_SIZE
         + "\nSENSORS="
@@ -1593,10 +1545,6 @@ public class Config {
     properties.put("QUERY_AGGREGATE_FUN", this.QUERY_AGGREGATE_FUN);
     properties.put("QUERY_LOWER_VALUE", this.QUERY_LOWER_VALUE);
     properties.put("QUERY_SEED", this.QUERY_SEED);
-    properties.put("QUERY_LIMIT_N", this.QUERY_LIMIT_N);
-    properties.put("QUERY_LIMIT_OFFSET", this.QUERY_LIMIT_OFFSET);
-    properties.put("QUERY_SLIMIT_N", this.QUERY_SLIMIT_N);
-    properties.put("QUERY_SLIMIT_OFFSET", this.QUERY_SLIMIT_OFFSET);
     properties.put("WORKLOAD_BUFFER_SIZE", this.WORKLOAD_BUFFER_SIZE);
     return properties;
   }

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
@@ -352,19 +352,6 @@ public class ConfigDescriptor {
                 properties.getProperty("GROUP_BY_TIME_UNIT", config.getGROUP_BY_TIME_UNIT() + "")));
         config.setQUERY_SEED(
             Long.parseLong(properties.getProperty("QUERY_SEED", config.getQUERY_SEED() + "")));
-        config.setQUERY_LIMIT_N(
-            Integer.parseInt(
-                properties.getProperty("QUERY_LIMIT_N", config.getQUERY_LIMIT_N() + "")));
-        config.setQUERY_LIMIT_OFFSET(
-            Integer.parseInt(
-                properties.getProperty("QUERY_LIMIT_OFFSET", config.getQUERY_LIMIT_OFFSET() + "")));
-        config.setQUERY_SLIMIT_N(
-            Integer.parseInt(
-                properties.getProperty("QUERY_SLIMIT_N", config.getQUERY_SLIMIT_N() + "")));
-        config.setQUERY_SLIMIT_OFFSET(
-            Integer.parseInt(
-                properties.getProperty(
-                    "QUERY_SLIMIT_OFFSET", config.getQUERY_SLIMIT_OFFSET() + "")));
 
         config.setWORKLOAD_BUFFER_SIZE(
             Integer.parseInt(


### PR DESCRIPTION
Some config parameters in config.properties are not in use, so remove it
  /** Maximum number of output items in conditional query with limit */
  private int QUERY_LIMIT_N = 1;
  /** The offset in conditional query with limit */
  private int QUERY_LIMIT_OFFSET = 0;
  /** Maximum number of output sequences */
  private int QUERY_SLIMIT_N = 1;
  /** Offset of output sequences */
  private int QUERY_SLIMIT_OFFSET = 0;