### PR TITLE
[TEST_MAX_TIME] add max time control of test

### DIFF
--- a/configuration/conf/config.properties
+++ b/configuration/conf/config.properties
@@ -39,6 +39,8 @@ LOOP=1000
 # verificationQueryMode 单数据库正确性查询模式，需要配置 FILE_PATH 以及 DATA_SET
 # serverMODE            服务器资源使用监控模式（该模式下运行通过ser-benchmark.sh脚本启动，无需手动配置该参数）
 BENCHMARK_WORK_MODE=testWithDefaultPath
+# 限制测试最长耗时，设置为0表示无限制，单位为ms
+TEST_MAX_TIME=0
 # 是否启动Benchmark统计模块
 USE_MEASUREMENT=true
 # Benchmark的统计信息结果的精度，单位为%

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/Client.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/Client.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class Client implements Runnable {
 
@@ -70,6 +71,9 @@ public abstract class Client implements Runnable {
   protected long totalLoop = 0;
   /** Loop Index, using for loop and log */
   protected long loopIndex = 0;
+
+  /** Control the status */
+  protected AtomicBoolean isStop = new AtomicBoolean(false);
 
   /** Control the end of client */
   private final CountDownLatch countDownLatch;
@@ -157,7 +161,7 @@ public abstract class Client implements Runnable {
     return measurement;
   }
 
-  /** Do test */
+  /** Do test, Notice please use `isStop` parameters to control */
   protected abstract void doTest();
 
   /** Init DBWrapper */
@@ -168,5 +172,10 @@ public abstract class Client implements Runnable {
       dbConfigs.add(config.getANOTHER_DBConfig());
     }
     dbWrapper = new DBWrapper(dbConfigs, measurement);
+  }
+
+  /** Stop client */
+  public void stopClient() {
+    this.isStop.set(true);
   }
 }

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/TimeClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/TimeClient.java
@@ -1,0 +1,37 @@
+package cn.edu.tsinghua.iotdb.benchmark.client;
+
+import cn.edu.tsinghua.iotdb.benchmark.conf.ConfigDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class TimeClient extends Thread {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeClient.class);
+  private Long testMaxTime = ConfigDescriptor.getInstance().getConfig().getTEST_MAX_TIME();
+
+  private List<Client> clients;
+
+  public TimeClient(List<Client> clients) {
+    this.clients = clients;
+  }
+
+  @Override
+  public void run() {
+    if (testMaxTime != 0) {
+      super.run();
+      boolean finished = false;
+      try {
+        Thread.sleep(testMaxTime);
+      } catch (InterruptedException e) {
+        finished = true;
+      }
+      if (!finished) {
+        LOGGER.info("It has been tested for " + testMaxTime + "ms, start to stop all clients.");
+        for (Client client : clients) {
+          client.stopClient();
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/generate/GenerateDataDeviceClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/generate/GenerateDataDeviceClient.java
@@ -83,6 +83,9 @@ public class GenerateDataDeviceClient extends GenerateBaseClient {
         LOGGER.info(
             "All points of {} have been checked", deviceQuery.getDeviceSchema().getDevice());
         pointService.shutdown();
+        if (isStop.get()) {
+          break;
+        }
       }
     } catch (SQLException | TsdbException sqlException) {
       LOGGER.error("Failed DeviceQuery: " + sqlException.getMessage());

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/generate/GenerateDataMixClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/generate/GenerateDataMixClient.java
@@ -99,6 +99,9 @@ public class GenerateDataMixClient extends GenerateBaseClient {
           LOGGER.error("Failed to do " + operation.getName() + " query because ", e);
         }
       }
+      if (isStop.get()) {
+        break;
+      }
       if (config.getOP_INTERVAL() > 0) {
         long elapsed = System.currentTimeMillis() - start;
         if (elapsed < config.getOP_INTERVAL()) {

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/generate/GenerateDataWriteClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/generate/GenerateDataWriteClient.java
@@ -41,6 +41,9 @@ public class GenerateDataWriteClient extends GenerateBaseClient {
       if (!doGenerate()) {
         break loop;
       }
+      if (isStop.get()) {
+        break;
+      }
     }
   }
 

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/real/RealDataSetQueryClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/real/RealDataSetQueryClient.java
@@ -43,6 +43,9 @@ public class RealDataSetQueryClient extends RealBaseClient {
         VerificationQuery verificationQuery = queryWorkLoad.getVerifiedQuery(batch);
         dbWrapper.verificationQuery(verificationQuery);
         loopIndex++;
+        if (isStop.get()) {
+          break;
+        }
       } catch (Exception e) {
         LOGGER.error("Failed to query one batch data because ", e);
       }

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/real/RealDataSetWriteClient.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/client/real/RealDataSetWriteClient.java
@@ -42,6 +42,9 @@ public class RealDataSetWriteClient extends RealBaseClient {
         }
         dbWrapper.insertOneBatch(batch);
         loopIndex++;
+        if (isStop.get()) {
+          break;
+        }
       } catch (DBConnectException e) {
         LOGGER.error("Failed to insert one batch data because ", e);
       } catch (Exception e) {

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/Config.java
@@ -71,6 +71,9 @@ public class Config {
    */
   private BenchmarkMode BENCHMARK_WORK_MODE = BenchmarkMode.TEST_WITH_DEFAULT_PATH;
 
+  /** The max time of test, unit: ms. if TEST_MAX_TIME is 0, there are no constraint. */
+  private Long TEST_MAX_TIME = 0L;
+
   /** Whether to use measurement */
   private boolean USE_MEASUREMENT = true;
   /** Precision of result, unit: % */
@@ -577,6 +580,14 @@ public class Config {
 
   public void setBENCHMARK_WORK_MODE(BenchmarkMode BENCHMARK_WORK_MODE) {
     this.BENCHMARK_WORK_MODE = BENCHMARK_WORK_MODE;
+  }
+
+  public Long getTEST_MAX_TIME() {
+    return TEST_MAX_TIME;
+  }
+
+  public void setTEST_MAX_TIME(Long TEST_MAX_TIME) {
+    this.TEST_MAX_TIME = TEST_MAX_TIME;
   }
 
   public boolean isUSE_MEASUREMENT() {
@@ -1648,6 +1659,8 @@ public class Config {
     }
 
     /* other config */
+    configProperties.addProperty("Extern Param", "TEST_MAX_TIME", this.TEST_MAX_TIME);
+
     configProperties.addProperty("Extern Param", "RESULT_PRECISION", this.RESULT_PRECISION + "%");
     configProperties.addProperty("Extern Param", "WORKLOAD_BUFFER_SIZE", this.WORKLOAD_BUFFER_SIZE);
 

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/conf/ConfigDescriptor.java
@@ -87,6 +87,9 @@ public class ConfigDescriptor {
         config.setLOOP(Long.parseLong(properties.getProperty("LOOP", config.getLOOP() + "")));
         config.setBENCHMARK_WORK_MODE(
             BenchmarkMode.getBenchmarkMode(properties.getProperty("BENCHMARK_WORK_MODE", "")));
+        config.setTEST_MAX_TIME(
+            Long.parseLong(
+                properties.getProperty("TEST_MAX_TIME", config.getTEST_MAX_TIME() + "")));
         config.setUSE_MEASUREMENT(
             Boolean.parseBoolean(
                 properties.getProperty("USE_MEASUREMENT", config.isUSE_MEASUREMENT() + "")));

--- a/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/mode/BaseMode.java
+++ b/core/src/main/java/cn/edu/tsinghua/iotdb/benchmark/mode/BaseMode.java
@@ -20,6 +20,7 @@
 package cn.edu.tsinghua.iotdb.benchmark.mode;
 
 import cn.edu.tsinghua.iotdb.benchmark.client.Client;
+import cn.edu.tsinghua.iotdb.benchmark.client.TimeClient;
 import cn.edu.tsinghua.iotdb.benchmark.client.operation.Operation;
 import cn.edu.tsinghua.iotdb.benchmark.conf.Config;
 import cn.edu.tsinghua.iotdb.benchmark.conf.ConfigDescriptor;
@@ -67,6 +68,10 @@ public abstract class BaseMode {
         return;
       }
       clients.add(client);
+    }
+    TimeClient timeClient = new TimeClient(clients);
+    timeClient.start();
+    for (Client client : clients) {
       executorService.submit(client);
     }
     start = System.nanoTime();
@@ -74,6 +79,9 @@ public abstract class BaseMode {
     try {
       // wait for all clients finish test
       downLatch.await();
+      if (timeClient.isAlive()) {
+        timeClient.interrupt();
+      }
     } catch (InterruptedException e) {
       LOGGER.error("Exception occurred during waiting for all threads finish.", e);
       Thread.currentThread().interrupt();


### PR DESCRIPTION
Add TEST_MAX_TIME parameters into benchmark to control the max test time.
if TEST_MAX_TIME = 0, there are no control, so benchmark will run all test.
if TEST_MAX_TIME not zero, benchmark will do loop no more than TEST_MAX_TIME ms.